### PR TITLE
Update AboutView.xaml

### DIFF
--- a/src/SyncTrayzor/Pages/AboutView.xaml
+++ b/src/SyncTrayzor/Pages/AboutView.xaml
@@ -61,7 +61,7 @@
         
         <TextBlock DockPanel.Dock="Top" Margin="0,5">
             <Hyperlink Command="{s:Action ShowHomepage}">
-                <TextBlock Text="{Binding HomepageUrl}"/>
+                <TextBlock Text="Github"/>
             </Hyperlink>
         </TextBlock>
         


### PR DESCRIPTION
The original Link too the Github Page is to long to be displayed. I have shortend the text to "Github" so the Hyperlink is correctly displayed.