### PR TITLE
fix: Ask CEF to not relaunch the process if running as admin

### DIFF
--- a/src/SyncTrayzor/Bootstrapper.cs
+++ b/src/SyncTrayzor/Bootstrapper.cs
@@ -94,10 +94,6 @@ namespace SyncTrayzor
         {
             LogManager.Setup().LoadConfigurationFromFile();
 
-            options = Container.Get<CommandLineOptionsParser>();
-            if (!options.Parse(Args))
-                Environment.Exit(0);
-
             var pathTransformer = Container.Get<IPathTransformer>();
 
             // Have to set the log path before anything else
@@ -107,9 +103,15 @@ namespace SyncTrayzor
             AppDomain.CurrentDomain.UnhandledException += (o, e) => OnAppDomainUnhandledException(e);
 
             var logger = LogManager.GetCurrentClassLogger();
+
             var assembly = Container.Get<IAssemblyProvider>();
             logger.Info("SyncTrazor version {0} ({1}) started at {2} (.NET version: {3})", assembly.FullVersion,
                 assembly.ProcessorArchitecture, assembly.Location, assembly.FrameworkDescription);
+            logger.Debug("Launched with command line {Args}", Args);
+
+            options = Container.Get<CommandLineOptionsParser>();
+            if (!options.Parse(Args))
+                Environment.Exit(0);
 
             // This needs to happen before anything which might cause the unhandled exception stuff to be shown, as that wants to know
             // where to find the log file.

--- a/src/SyncTrayzor/Pages/ViewerViewModel.cs
+++ b/src/SyncTrayzor/Pages/ViewerViewModel.cs
@@ -122,6 +122,12 @@ namespace SyncTrayzor.Pages
                     Locale = language
                 };
 
+                // CEF will attempt de-elevating the process when launched as admin. This is done by relaunching
+                // the current process in unprivileged mode. However, we're not equipped to handle such a
+                // process restart cleanly, so ask CEF to not relaunch. Running as admin is not ideal for security,
+                // but the user wants it...
+                settings.CefCommandLineArgs.Add("do-not-de-elevate");
+
                 // System proxy settings (which also specify a proxy for localhost) shouldn't affect us
                 settings.CefCommandLineArgs.Add("no-proxy-server", "1");
                 settings.CefCommandLineArgs.Add("disable-cache", "1");


### PR DESCRIPTION
CEF has a security feature that attempts to de-elevate when running as admin. This improves user security in case of exploits. However, CEF relaunches the "outer" process (e.g. our main process), not only the browser subprocess. We're not equipped to handle unannounced hidden process restarts for several reasons:

* CEF passes all of its configuration as command line arguments to the outer process, which doesn't understand them
* We may attempt to hold locks or resources to files (such as log files) multiple times, as we load CEF quite late in the init loop. CEF does not forcefully terminate the "old" process when relaunching.

This relaunch design appears nontrivial to support from our perspective. The easy fix is to disable the de-elevation feature. This isn't great for user security unfortunately.

Possibly fixes #80 #55