### PR TITLE
fix(popup): Fix inverted order of items when initializing (fixes #149)

### DIFF
--- a/src/SyncTrayzor/Pages/Tray/FileTransfersTrayViewModel.cs
+++ b/src/SyncTrayzor/Pages/Tray/FileTransfersTrayViewModel.cs
@@ -59,7 +59,7 @@ namespace SyncTrayzor.Pages.Tray
 
         protected override void OnActivate()
         {
-            foreach (var completedTransfer in syncthingManager.TransferHistory.CompletedTransfers.Reverse())
+            foreach (var completedTransfer in syncthingManager.TransferHistory.CompletedTransfers)
             {
                 AddCompletedTransfer(new FileTransferViewModel(completedTransfer));
             }


### PR DESCRIPTION
Reverse() isn't necessary here, as AddCompletedTransfer() automatically handles the correct insert order

Fixes: #149 