### PR TITLE
feat(popup): Remember popup width and height, add option to keep on top

### DIFF
--- a/src/SyncTrayzor/Pages/Settings/SettingsView.xaml
+++ b/src/SyncTrayzor/Pages/Settings/SettingsView.xaml
@@ -75,6 +75,7 @@
                                 <CheckBox DockPanel.Dock="Top" IsChecked="{Binding ShowDeviceOrFolderRejectedBalloons.Value}" Content="{l:Loc SettingsView_ShowDeviceOrFolderRejectedBalloons}"/>
                                 <CheckBox DockPanel.Dock="Top" IsChecked="{Binding ShowTrayIconOnlyOnClose.Value}" Content="{l:Loc SettingsView_OnlyShowTrayIconOnClose}"/>
                                 <CheckBox DockPanel.Dock="Top" IsChecked="{Binding KeepActivityPopupOpen.Value}" Content="{l:Loc SettingsView_KeepActivityPopupOpen}"/>
+                                <CheckBox DockPanel.Dock="Top" IsChecked="{Binding KeepActivityPopupOnTop.Value}" Content="{l:Loc SettingsView_KeepActivityPopupOnTop}"/>
                                 <StackPanel DockPanel.Dock="Top" Orientation="Horizontal" Margin="0,5,0,0">
                                     <Label Padding="0,0,5,0" Target="{Binding ElementName=IconAnimationModeSelect}" VerticalAlignment="Center" Content="{l:Loc SettingsView_AnimateTrayIcon}"/>
                                     <ComboBox x:Name="IconAnimationModeSelect" ItemsSource="{Binding IconAnimationModes}" SelectedValuePath="Value" SelectedValue="{Binding IconAnimationMode.Value}"/>

--- a/src/SyncTrayzor/Pages/Settings/SettingsViewModel.cs
+++ b/src/SyncTrayzor/Pages/Settings/SettingsViewModel.cs
@@ -71,6 +71,9 @@ namespace SyncTrayzor.Pages.Settings
         public SettingItem<bool> ShowDeviceConnectivityBalloons { get; }
         public SettingItem<bool> ShowDeviceOrFolderRejectedBalloons { get; }
         public SettingItem<bool> KeepActivityPopupOpen { get; }
+        public SettingItem<bool> KeepActivityPopupOnTop { get; }
+        public SettingItem<int> ActivityPopupWidth { get; }
+        public SettingItem<int> ActivityPopupHeight { get; }
 
         public BindableCollection<LabelledValue<IconAnimationMode>> IconAnimationModes { get; }
         public SettingItem<IconAnimationMode> IconAnimationMode { get; }
@@ -143,6 +146,9 @@ namespace SyncTrayzor.Pages.Settings
             ShowDeviceConnectivityBalloons = CreateBasicSettingItem(x => x.ShowDeviceConnectivityBalloons);
             ShowDeviceOrFolderRejectedBalloons = CreateBasicSettingItem(x => x.ShowDeviceOrFolderRejectedBalloons);
             KeepActivityPopupOpen = CreateBasicSettingItem(x => x.KeepActivityPopupOpen);
+            KeepActivityPopupOnTop = CreateBasicSettingItem(x => x.KeepActivityPopupOnTop);
+            ActivityPopupWidth = CreateBasicSettingItem(x => x.ActivityPopupWidth);
+            ActivityPopupHeight = CreateBasicSettingItem(x => x.ActivityPopupHeight );
 
             IconAnimationModes = new BindableCollection<LabelledValue<IconAnimationMode>>()
             {

--- a/src/SyncTrayzor/Properties/Resources.resx
+++ b/src/SyncTrayzor/Properties/Resources.resx
@@ -1006,6 +1006,10 @@ Please donate to the syncthing project.</value>
     <value>Keep activity popup open</value>
     <comment>Description for checkbox in settings menu</comment>
   </data>
+  <data name="SettingsView_KeepActivityPopupOnTop" xml:space="preserve">
+    <value>Keep activity popup on top</value>
+    <comment>Description for checkbox in settings menu</comment>
+  </data>
   <data name="ConflictResolutionView_FileName_FileDeleted" xml:space="preserve">
     <value>[File Deleted]</value>
     <comment>When the base file for a conflict is not found, this placeholder is shown instead of the actual file name</comment>

--- a/src/SyncTrayzor/Services/Config/Configuration.cs
+++ b/src/SyncTrayzor/Services/Config/Configuration.cs
@@ -29,6 +29,9 @@ namespace SyncTrayzor.Services.Config
         public bool ShowDeviceOrFolderRejectedBalloons { get; set; }
         public bool ShowSynchronizedBalloonEvenIfNothingDownloaded { get; set; }
         public bool KeepActivityPopupOpen { get; set; }
+        public bool KeepActivityPopupOnTop { get; set; }
+        public int ActivityPopupWidth { get; set; }
+        public int ActivityPopupHeight { get; set; }
         public string SyncthingAddress { get; set; }
         public bool StartSyncthingAutomatically { get; set; }
 
@@ -112,6 +115,9 @@ namespace SyncTrayzor.Services.Config
             ShowFileInFolderCommand = "explorer.exe /select, \"{0}\"";
             LogLevel = LogLevel.Info;
             KeepActivityPopupOpen = false;
+            KeepActivityPopupOnTop = true;
+            ActivityPopupWidth = 300;
+            ActivityPopupHeight = 350;
         }
 
         public Configuration(Configuration other)
@@ -151,6 +157,9 @@ namespace SyncTrayzor.Services.Config
             ShowFileInFolderCommand = other.ShowFileInFolderCommand;
             LogLevel = other.LogLevel;
             KeepActivityPopupOpen = other.KeepActivityPopupOpen;
+            KeepActivityPopupOnTop = other.KeepActivityPopupOnTop;
+            ActivityPopupWidth = other.ActivityPopupWidth;
+            ActivityPopupHeight = other.ActivityPopupHeight;
         }
 
         public override string ToString()
@@ -170,7 +179,10 @@ namespace SyncTrayzor.Services.Config
                 $"ConflictResolverDeletesToRecycleBin={ConflictResolverDeletesToRecycleBin} PauseDevicesOnMeteredNetworks={PauseDevicesOnMeteredNetworks} " +
                 $"HaveDonated={HaveDonated} IconAnimationMode={IconAnimationMode} OpenFolderCommand={OpenFolderCommand} ShowFileInFolderCommand={ShowFileInFolderCommand}" +
                 $"LogLevel={LogLevel}" +
-                $"KeepActivityPopupOpen={KeepActivityPopupOpen}>";
+                $"KeepActivityPopupOpen={KeepActivityPopupOpen}>" +
+                $"KeepActivityPopupOnTop={KeepActivityPopupOnTop}>" +
+                $"ActivityPopupWindowWidth={ActivityPopupWidth}>"+
+                $"ActivityPopupWindowHeight={ActivityPopupHeight}>";
         }
     }
 }


### PR DESCRIPTION
- The popup view will save its width and height to configuration when deactivated.
- Added a new settings checkbox to toggle keeping the popup on top of other windows or not.
- If `keep open` is false, the popup window won't appear in the taskbar now (but will if `keep open` is true).