### PR TITLE
fix(conflicts): Improve conflict finder regex

### DIFF
--- a/src/SyncTrayzor/Services/Conflicts/ConflictFileManager.cs
+++ b/src/SyncTrayzor/Services/Conflicts/ConflictFileManager.cs
@@ -109,7 +109,7 @@ namespace SyncTrayzor.Services.Conflicts
 
         private static readonly Regex conflictRegex =
             new(
-                @"^(?<prefix>.*).sync-conflict-(?<year>\d{4})(?<month>\d{2})(?<day>\d{2})-(?<hours>\d{2})(?<mins>\d{2})(?<secs>\d{2})(-(?<device>[a-zA-Z0-9]+))?(?<suffix>.*)(?<extension>\..*)$");
+                @"^(?<prefix>.*)\.sync-conflict-(?<year>\d{4})(?<month>\d{2})(?<day>\d{2})-(?<hours>\d{2})(?<mins>\d{2})(?<secs>\d{2})-(?<device>[a-zA-Z0-9]+)?(?<suffix>.*(?=\.))?(?<extension>\..*)?$");
 
         private static readonly Logger logger = LogManager.GetCurrentClassLogger();
         private const int maxSearchDepth = 255; // Loosely based on the max path length (a bit over)


### PR DESCRIPTION
Fixes issue #180 

Improve the base regex in the conflicts finder, so that it supports filenames without extension.

Reference: Syncthing's conflict filename generator https://github.com/syncthing/syncthing/blob/43d826913f917b0f2c692f0ecf90823e2e0528d7/lib/model/folder_sendrecv.go#L2227 `return name[:len(name)-len(ext)] + time.Now().Format(".sync-conflict-20060102-150405-") + lastModBy + ext`

Changes:
- `.sync-` -> `\.sync`: properly escape this dot that is always present in the conflict filename.
- `(-(?<device>[a-zA-Z0-9]+))?` -> `-(?<device>[a-zA-Z0-9]+)?`: the dash is always present, even if there was no `lastModBy` device. Do not tag it as optional.
- `(?<suffix>.*)` -> `(?<suffix>.*(?=\.))?`: This will match all the stuff that other software could add before the extension and after the syncthing conflict tag, by matching until the last `.` in the filename. This named group should be optional
- `(?<extension>\..*)` -> `(?<extension>\..*)?`: Make extension optional