### PR TITLE
fix: refresh outdated default Syncthing binary

### DIFF
--- a/src/SyncTrayzor/Services/Config/ConfigurationProvider.cs
+++ b/src/SyncTrayzor/Services/Config/ConfigurationProvider.cs
@@ -116,7 +116,8 @@ namespace SyncTrayzor.Services.Config
             }
 
             // This is duplicated between here and ConfigurationApplicator, and it's ugly.
-            var expandedSyncthingPath = string.IsNullOrWhiteSpace(currentConfig.SyncthingCustomPath) ?
+            var usingDefaultSyncthingPath = string.IsNullOrWhiteSpace(currentConfig.SyncthingCustomPath);
+            var expandedSyncthingPath = usingDefaultSyncthingPath ?
                 paths.DefaultSyncthingPath :
                 pathTransformer.MakeAbsolute(currentConfig.SyncthingCustomPath);
 
@@ -134,6 +135,20 @@ namespace SyncTrayzor.Services.Config
 
                 filesystem.Copy(paths.SyncthingBackupPath, expandedSyncthingPath);
                 SyncthingInstalled = true;
+            }
+            else if (usingDefaultSyncthingPath &&
+                     !String.Equals(Path.GetFullPath(expandedSyncthingPath), Path.GetFullPath(paths.SyncthingBackupPath), StringComparison.OrdinalIgnoreCase) &&
+                     filesystem.FileExists(paths.SyncthingBackupPath))
+            {
+                var installedVersion = filesystem.GetFileVersion(expandedSyncthingPath);
+                var bundledVersion = filesystem.GetFileVersion(paths.SyncthingBackupPath);
+                if (installedVersion != null && bundledVersion != null && bundledVersion > installedVersion)
+                {
+                    logger.Info("Updating the default Syncthing binary at {Path} from {InstalledVersion} to bundled version {BundledVersion}",
+                        expandedSyncthingPath, installedVersion, bundledVersion);
+                    filesystem.Copy(paths.SyncthingBackupPath, expandedSyncthingPath, overwrite: true);
+                    SyncthingInstalled = true;
+                }
             }
 
             if (updateConfigInstallCount)

--- a/src/SyncTrayzor/Services/FilesystemProvider.cs
+++ b/src/SyncTrayzor/Services/FilesystemProvider.cs
@@ -1,5 +1,6 @@
 ﻿using SyncTrayzor.Utils;
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Collections.Generic;
 
@@ -13,7 +14,8 @@ namespace SyncTrayzor.Services
         FileStream Open(string path, FileMode fileMode, FileAccess fileAccess, FileShare fileShare);
         FileStream CreateAtomic(string path);
         FileStream OpenRead(string path);
-        void Copy(string from, string to);
+        void Copy(string from, string to, bool overwrite = false);
+        Version GetFileVersion(string path);
         void MoveFile(string from, string to);
         void CreateDirectory(string path);
         void DeleteFile(string path);
@@ -48,7 +50,13 @@ namespace SyncTrayzor.Services
 
         public FileStream OpenRead(string path) => File.OpenRead(path);
 
-        public void Copy(string from, string to) => File.Copy(from, to);
+        public void Copy(string from, string to, bool overwrite = false) => File.Copy(from, to, overwrite);
+
+        public Version GetFileVersion(string path)
+        {
+            var fileVersion = FileVersionInfo.GetVersionInfo(path).FileVersion?.Trim();
+            return Version.TryParse(fileVersion, out var version) ? version : null;
+        }
 
         public void MoveFile(string from, string to) => File.Move(from, to);
 


### PR DESCRIPTION
## Summary

- Refreshes the default per-user Syncthing executable when the bundled executable is newer.
- Leaves custom Syncthing paths untouched.
- Prevents an older installed binary from failing to read configuration written by a newer bundled version.

## Testing

- `dotnet test src -c Release --no-restore`
- 58 tests passed.