### PR TITLE
build: update bundled Syncthing to v2.1.3

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -3,7 +3,7 @@
 version: "3"
 
 vars:
-   DOWNLOAD_SYNCTHING_VERSION: "v2.0.3"
+   DOWNLOAD_SYNCTHING_VERSION: "v2.1.3"
 
 tasks:
    download-syncthing:

--- a/scripts/download-syncthing.ps1
+++ b/scripts/download-syncthing.ps1
@@ -6,8 +6,14 @@ $ErrorActionPreference = "Stop"
 $outdir = "syncthing"
 
 if (Test-Path "$outdir/syncthing.exe") {
-    Write-Host "Syncthing already downloaded in $outdir. Skipping download."
-    exit 0
+    $versionOutput = & "$outdir/syncthing.exe" version 2>$null | Select-Object -First 1
+    $currentVersion = ($versionOutput -split '\s+')[1]
+    if ($currentVersion -eq $Version) {
+        Write-Host "Syncthing $Version already downloaded in $outdir. Skipping download."
+        exit 0
+    }
+
+    Write-Host "Found Syncthing $currentVersion in $outdir; replacing it with $Version."
 }
 
 . "$PSScriptRoot\helpers\get-arch.ps1"
@@ -39,7 +45,7 @@ Expand-Archive -Path $zipPath -DestinationPath $outdir -Force
 # Optionally move binaries up from the nested folder
 $extractedRoot = Join-Path $outdir "syncthing-windows-$arch-$Version"
 if (Test-Path $extractedRoot) {
-    Move-Item -Path (Join-Path $extractedRoot '*') -Destination $outdir -Force
+    Copy-Item -Path (Join-Path $extractedRoot '*') -Destination $outdir -Recurse -Force
     Remove-Item $extractedRoot -Recurse -Force
 }
 


### PR DESCRIPTION
## Summary

- Updates the bundled Syncthing download version from v2.0.3 to v2.1.3.
- Replaces an already-downloaded build when its version does not match the requested version.
- Preserves nested files while moving extracted Syncthing contents into the download directory.

## Testing

- `dotnet test src -c Release --no-restore`
- 58 tests passed.